### PR TITLE
Fix bug: convert_pbf_to_o5m is not a method of app

### DIFF
--- a/osm_downloader.py
+++ b/osm_downloader.py
@@ -59,7 +59,7 @@ def update_osm_data(app):
         call('mv %s %s' % (app.countryO5M, app.oldCountryO5M), shell=True)
     else:
         print "O5M is missing, I'll try to convert the PBF file..."
-        app.convert_pbf_to_o5m(app)
+        convert_pbf_to_o5m(app)
     call('osmupdate -v -B=%s %s %s' % (app.countryPoly, app.oldCountryO5M, app.countryO5M), shell=True)
     if os.path.isfile(app.countryO5M):
         print "\n- %s has been updated, removing temporary file %s" % (app.countryO5M, app.oldCountryO5M)


### PR DESCRIPTION
Probably a bug folloqing the code refactor, `convert_pbf_to_o5m` is part of `osm_downloader.py`.
With this change everything works.

(It should be noted that this method is invoked because there is no `italy.poly` in poly `data/OSM`).

Cristian
