### PR TITLE
Add option for locale [default: get system locale]

### DIFF
--- a/config.template
+++ b/config.template
@@ -12,6 +12,10 @@ libspatialite-path = /usr/lib/x86_64-linux-gnu/libspatialite.so.5.1.0
 #directory where html files must be copied after creation (optional, mandatory if --copy)
 outdir =
 
+[i18n]
+#supported locales
+supported_locales = it_IT | en_US
+
 [themes]
 #add an option (line) for each theme and its categories
 #theme name = category A name|category B name|category C name...

--- a/launch_script.py
+++ b/launch_script.py
@@ -283,7 +283,20 @@ The number of tagged articles will replace that of the lust run in the tags' num
         ifile.close()
 
         #Create webpages
-        for locale_langcode in self.args.locales:
+
+        # Restrict to the supported locales
+        self.locales = frozenset(self.SUPPORTED_LOCALES).intersection(
+            self.args.locales)
+
+        non_supported_locales = self.args.locales - self.SUPPORTED_LOCALES
+        for locale in non_supported_locales:
+            print 'Warning: dropping unsupported locale: ', locale
+
+        # if no supported locale is chosen fallback to en_US
+        if not self.locales:
+            self.locales = frozenset(['en_US'])
+
+        for locale_langcode in self.locales:
             self.translations = Translations.load("locale", [locale_langcode])
             self._ = self.translations.ugettext
             if self.args.create_webpages:
@@ -425,6 +438,12 @@ The number of tagged articles will replace that of the lust run in the tags' num
         self.MISSINGTEMPLATESDIR = os.path.join("data", "wikipedia", "missing_templates")
         self.make_dir(self.MISSINGTEMPLATESDIR)
         self.TEMPLATESSTATUSFILE = os.path.join(self.MISSINGTEMPLATESDIR, "missing_templates.csv")
+
+        supported_locales = configparser.get("i18n", "supported_locales")
+        self.SUPPORTED_LOCALES = [lcode.strip()
+                                  for lcode in supported_locales.split('|')
+                                  ]
+
         return themesAndCatsNames
 
     def make_dir(self, path):


### PR DESCRIPTION
Hi,

`locale` is a python system module and thus should work on any system.

This pull request is missing a check over the supported locales, and some sort of fallback system/exception handling in case a locale that is not avaible is requested.

Please find below two example generated with the `en_US` locale:
![wikipedia articles which can be mapped in openstreetmap - mozilla firefox_137](https://cloud.githubusercontent.com/assets/367272/3919094/e1442af4-23a2-11e4-8cc7-2564b08f596d.png)
![wikipedia articles which can be mapped in openstreetmap - mozilla firefox_136](https://cloud.githubusercontent.com/assets/367272/3919095/e145a6e0-23a2-11e4-82af-fa8212389428.png)

Cristian
