### PR TITLE
Fix: missing wikipedia template icon not show

### DIFF
--- a/webpages_creator.py
+++ b/webpages_creator.py
@@ -350,6 +350,7 @@ class Creator():
                                                         filename = filename,
                                                         item=category)
                 category.html = category.html.replace('{{root}}', '../../')
+                category.html = category.html.replace('{root}', '../../')
 
         print "  render regions subpages"
         #regions (subpages)
@@ -369,6 +370,7 @@ class Creator():
                                                 item=region)
 
             region.html = region.html.replace('{{root}}', '../../')
+            region.html = region.html.replace('{root}', '../../')
 
         #Create errors page
         print "  render errors page"


### PR DESCRIPTION
As per subject.
The icon for "Missing Wikipedia templates" still had their path as follows:
`src={root}img...`

This change fix that bug.

Cristian
